### PR TITLE
Add lua tests for CHERI riscv64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 # Output folders
 out-*
+!out-lua/Makefile

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["buildbot/capablevms-test-script"]
 
-timeout_sec = 600 # 10 minutes
+timeout_sec = 6000 # 1.6h
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true

--- a/out-lua/Makefile
+++ b/out-lua/Makefile
@@ -1,4 +1,5 @@
 CC ?= clang
+SSHPORT ?= 10021
 .PHONY: all clean
 
 all: $(patsubst %.bc,lib%.so,$(wildcard *.bc)) lua.shared
@@ -7,7 +8,15 @@ clean:
 	rm *.so *.bc lua.shared
 
 lua.shared: _main.bc
-	$(CC) $< -L. $(patsubst %.bc,-l%,$(filter-out _main.bc,$(wildcard *.bc))) -L. -ldl -lm -g -Wl,-rpath,$(shell pwd) -o lua.shared
+	$(CC) $(CFLAGS) $< -L. -L/root/lua $(patsubst %.bc,-l%,$(filter-out _main.bc,$(wildcard *.bc))) -L. -L/root/lua -ldl -lm -g -Wl,-rpath,/root/lua -o lua.shared
 	
 lib%.so: %.bc
-	$(CC) -shared -fuse-ld=lld -fPIC $< -o lib$(basename $<).so
+	$(CC) $(CFLAGS) -shared -fPIC $< -o lib$(basename $<).so
+
+copy-lua:
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) root@localhost "mkdir -p /root/lua"
+	scp $(SCP_OPTIONS) -P $(SSHPORT) lua.shared *.so root@localhost:/root/lua/.
+
+copy-exec-tests:
+	scp $(SCP_OPTIONS) -P $(SSHPORT) -r ../tests-lua root@localhost:/root/lua/.
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) root@localhost "cd /root/lua/tests-lua; sh test.sh"

--- a/tests-lua/mandelbrot/Makefile
+++ b/tests-lua/mandelbrot/Makefile
@@ -1,4 +1,4 @@
-FILE=mandelbrot.lua-6.lua
+FILE=mandelbrot.lua-3.lua
 
 run:
 	$(LUA) $(FILE) 100 > out

--- a/tests-lua/test.sh
+++ b/tests-lua/test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-export LUA=../../out-lua/lua.shared
+export LUA=../../lua.shared
 
 rc="0"
 

--- a/tests/run_cheri_tests.py
+++ b/tests/run_cheri_tests.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 The CapableVMs "CHERI Examples && LLVM FUNCTION SPLIT" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# This is expected to be run only from `.buildbot.sh`.
+#
+# This starts a `qemu-system` to run the tests and then safely shutdown the VM.
+# This relies on infrastructure provided by cheribuild:
+#   https://github.com/CTSRD-CHERI/cheribuild/tree/master/test-scripts
+
+import argparse
+import os
+import sys
+from pathlib import Path
+import importlib.util
+
+# The cheribuild infrastructure expects the first entry in sys.path to be
+# $CHERIBUILD/test-scripts, as if this script exists in that directory. This
+# script should work in such an environment, but we typically fake it by setting
+# PYTHONPATH (in `.buildbot.sh`), then dropping this script's actual directory
+# from sys.path.
+#
+# This avoids the need to write outside the buildbot test directory.
+
+test_scripts_dir = str(Path(importlib.util.find_spec("run_tests_common").origin).parent.absolute())
+sys.path = sys.path[sys.path.index(test_scripts_dir):]
+
+from run_tests_common import boot_cheribsd, run_tests_main
+
+
+def run_cheri_tests(qemu: boot_cheribsd.QemuCheriBSDInstance, args: argparse.Namespace) -> bool:
+    if args.sysroot_dir is not None:
+        boot_cheribsd.set_ld_library_path_with_sysroot(qemu)
+    boot_cheribsd.info("Running Lua tests on CHERI riscv64")
+
+    return os.system("make copy-lua copy-exec-tests") == 0
+
+
+if __name__ == '__main__':
+    run_tests_main(test_function=run_cheri_tests, need_ssh=True, should_mount_builddir=False)


### PR DESCRIPTION
- Ensure we can apply the splitter to lua and run it on CHERI riscv64;
- add a few reproducible steps which modify the Makefile in-place
to create `.bc` files instead of `.o` files;
- replace `mandelbrot-lua-6` with `mandelbrot-lua-3` because it
fails even on "normal" CHERI riscv64, i.e. without applying the splitter