### PR TITLE
Fix visibility issues with global variables and functions

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -37,6 +37,8 @@ cd ..
 
 # Test the handling of `extern` variables of type `const * const` when joining
 make CC=$CC CXX=$CHERI/bin/clang++ CFLAGS="--config cheribsd-riscv64-purecap.cfg" LLVM_CONFIG=$CHERI/bin/llvm-config LLVM_LINK=$LLVM_LINK LD_LIBRARY_PATH=$LD_LIBRARY_PATH test-extern-const-constptr
+# Test visibility is correctly set on global variables and functions
+make CC=$CC CXX=$CHERI/bin/clang++ CFLAGS="--config cheribsd-riscv64-purecap.cfg" LLVM_CONFIG=$CHERI/bin/llvm-config LLVM_LINK=$LLVM_LINK LD_LIBRARY_PATH=$LD_LIBRARY_PATH test-visibility
 
 tmpdir=/tmp/lua-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)/
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LLVM_CONFIG=llvm-config
 LLVM_LINK?=llvm-link
 CFORMAT ?= clang-format
 CPPFILES = $(wildcard *.cpp)
-CFILES = $(wildcard tests/**/*.c)
+CFILES = $(wildcard tests/**/*.c) $(wildcard tests/**/**/*.c)
 export
 
 all: manual-split find-and-split-static split-llvm-extract
@@ -32,6 +32,18 @@ test-global-dependency: tests/test-global-dependency.c
 	./split-llvm-extract test.bc -o out
 
 test-extern-const-constptr: $(wildcard tests/test-extern-const-constptr/*.c)
+	rm -Rf *.bc
+	rm -Rf out
+	mkdir -p out
+	$(CC) -fPIC -c -emit-llvm $^
+	$(LLVM_LINK) *.bc -o test.bc
+	./split-llvm-extract test.bc -o out
+	cp tests/Makefile out/.
+	cd out && $(MAKE)
+	rm -Rf out
+
+test-visibility: $(wildcard tests/test-visibility/*.c)
+	rm -Rf *.bc
 	rm -Rf out
 	mkdir -p out
 	$(CC) -fPIC -c -emit-llvm $^

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["buildbot/capablevms-test-script"]
 
-timeout_sec = 6000 # 1.6h
+timeout_sec = 12000 # 3.2h
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true

--- a/split-llvm-extract.cpp
+++ b/split-llvm-extract.cpp
@@ -232,15 +232,9 @@ int main(int argc, char **argv)
 
 	for (auto &global : loadedModule->globals())
 	{
-		if (global.isConstant())
-		{
-			global.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-			global.setDSOLocal(false);
-			continue;
-		}
-		global.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-		global.setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
 		global.setDSOLocal(false);
+		global.setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+		global.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
 	}
 
 	for (auto &function : loadedModule->functions())
@@ -249,9 +243,9 @@ int main(int argc, char **argv)
 		{
 			continue;
 		}
-		function.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-		function.setLinkage(llvm::GlobalValue::ExternalLinkage);
 		function.setDSOLocal(false);
+		function.setLinkage(llvm::GlobalValue::ExternalLinkage);
+		function.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
 	}
 
 	if (!dry)
@@ -329,10 +323,8 @@ int main(int argc, char **argv)
 		{
 			continue;
 		}
-		global.setInitializer(nullptr);
-		global.setVisibility(llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
-		global.setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
 		global.setDSOLocal(false);
+		global.setInitializer(nullptr);
 	}
 
 	if (!dry)

--- a/tests/test-visibility/pgcommon.c
+++ b/tests/test-visibility/pgcommon.c
@@ -1,0 +1,10 @@
+#include "pgcommon.h"
+
+static const PROBLEMATIC_STRUCT problematic_data = {2};
+const PROBLEMATIC_STRUCT *const PROBLEMATIC_STRUCT_default = &problematic_data;
+
+int pglz_compress2(const PROBLEMATIC_STRUCT *prob)
+{
+	prob = PROBLEMATIC_STRUCT_default;
+	return prob->two;
+}

--- a/tests/test-visibility/pgcommon.h
+++ b/tests/test-visibility/pgcommon.h
@@ -1,0 +1,9 @@
+typedef struct PROBLEMATIC_STRUCT
+{
+	int two;
+} PROBLEMATIC_STRUCT;
+
+extern const PROBLEMATIC_STRUCT *const PROBLEMATIC_STRUCT_default;
+
+// Global function declaration
+extern int pglz_compress2(const PROBLEMATIC_STRUCT *prob);

--- a/tests/test-visibility/pgcommon_main.c
+++ b/tests/test-visibility/pgcommon_main.c
@@ -1,0 +1,10 @@
+#include "pgcommon.h"
+#include <stdio.h>
+
+int main(void)
+{
+	int what = pglz_compress2(PROBLEMATIC_STRUCT_default);
+	printf("Just trying to reproduce the bug. Value: %d\n", what);
+
+	return 0;
+}


### PR DESCRIPTION
Some variables and functions are marked as `hidden` by the splitter and so then cannot be found by the linker. Setting the visibility as `default` at different stages fixes the problems which, otherwise, would prevent a correct joining phase.