### PR TITLE
Add architecture check to .buildbot.sh

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+if ! [ "$1" = "riscv64" ]; then
+	echo "Only riscv64 is supported."
+	# Exit gracefully because we do not want the build to fail
+	exit 0
+fi
+
 find . -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" -o -iname "*.hpp" | xargs ~/cheri/output/sdk/bin/clang-format --dry-run -Werror
 
 repodir=$(pwd)


### PR DESCRIPTION
As we have discussed recently with Andrei too, our infrastructure is highly tailored on `cheri-examples` where we test multiple architectures. The splitter works only on `riscv64`. Since `.buildbot.sh` is called with multiple arguments by our worker, it executes the same tests twice if there is no guard. In fact, calling `.buildbot.sh` with `riscv64` or `morello-hybrid` in this repository, will always result in `riscv64` (since there is no check in `.buildbot.sh`).