### PR TITLE
Remove residual debugging info/facilities

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -13,7 +13,7 @@ if [ "$1" = "morello-purecap" ]; then
 	CONFIG_FLAGS="-target aarch64-unknown-freebsd13 \
 	  --sysroot=${HOME}/cheri/output/rootfs-morello-purecap \
 	  -B${HOME}/cheri/output/morello-sdk/bin \
-	  -mcpu=rainier -march=morello+c64 -mabi=purecap -Xclang -morello-vararg=new -g"
+	  -mcpu=rainier -march=morello+c64 -mabi=purecap -Xclang -morello-vararg=new"
 	SSHPORT=10085
 	args=(
 	--architecture morello-purecap

--- a/Makefile
+++ b/Makefile
@@ -62,16 +62,6 @@ test-visibility: $(wildcard tests/test-visibility/*.c)
 	cd out && $(MAKE)
 	rm -Rf out
 
-test-ext-lu: $(wildcard tests/test-ext-lu/*.c)
-	rm -Rf *.bc
-	rm -Rf out
-	mkdir -p out
-	$(CC) --config cheribsd-morello-purecap.cfg -fPIC -c -emit-llvm $^
-	$(LLVM_LINK) *.bc -o test.bc
-	./split-llvm-extract test.bc -o out
-	cp tests/Makefile out/.
-	cd out && $(MAKE)
-
 test-compile: out
 	$(CC) $(wildcard out/*.bc) -o out/executable
 


### PR DESCRIPTION
Some "-g" and residual fake test in the Makefile. They have no use and can confuse future contributors.